### PR TITLE
Added 'A Visual Git Reference'.

### DIFF
--- a/usingGit
+++ b/usingGit
@@ -1,5 +1,10 @@
+A few helpful references when learning Git.
+
 A 'man'-page reference for each command.
 http://git-scm.com/docs/
+
+"A Visual Git Reference" for a few common commands.
+http://marklodato.github.io/visual-git-guide/index-en.html
 
 Git Reference
 "quick reference for learning and remembering the most important and commonly used Git commands."


### PR DESCRIPTION
Changed the name from 'usingGithub' to 'usingGit', because the references just talk about Git, not about GitHub. Even if some GitHub references are added later, this particular document is primarily about general Git commands and practices, so it makes sense to fix the file name.

Also, added a reference to a web page that explains a few common commands by showing diagrams of branches and commit objects that explain the changes that occur with each command.
